### PR TITLE
Fixed an issue with es6 module sorting

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = () => (
         const dependency = source.split('/')[0];
 
         const dependencyPathRegexp = new RegExp(
-          `(${dependencies.join('|')})(\\${pathUtils.sep}(components|themes|utils))?$`
+          `(${dependencies.join('|')})(\\${pathUtils.sep}(components|contexts|themes|utils))?$`
         );
         const matches = dependencyPathRegexp.exec(source);
         if (matches) {

--- a/index.js
+++ b/index.js
@@ -15,44 +15,39 @@ module.exports = () => (
         const matches = dependencyPathRegexp.exec(source);
         if (matches) {
           const context = matches[0];
+          const stripRegExp = new RegExp(`node_modules\\${pathUtils.sep}|\.js`, 'g');
           const modulesInContext = find.fileSync(
             /\.js$/, pathUtils.join('.', 'node_modules', context)
           ).map(
-            file => file.replace(new RegExp(`node_modules\\${pathUtils.sep}|\.js`, 'g'), '')
+            file => file.replace(stripRegExp, '')
           ).filter(
             // remove grommet-icons inside grommet node_modules
             file => file.indexOf(pathUtils.join(dependency, 'grommet-icons')) === -1
-          ).reverse(); // reverse so es6 modules have higher priority
+          );
           const memberImports = path.node.specifiers.filter(
             specifier => specifier.type === 'ImportSpecifier'
           );
 
           const transforms = [];
+          const development = process.env.NODE_ENV === 'development';
+          const es6 = `${pathUtils.sep}es6${pathUtils.sep}`;
           memberImports.forEach((memberImport) => {
             const componentName = memberImport.imported.name;
-            let newPath;
-            modulesInContext.some((module) => {
-              // if webpack alias is enabled the es6 path does not exist.
-              if (module.endsWith(`${pathUtils.sep}${componentName}`)) {
-                if (process.env.NODE_ENV === 'development') {
-                  // in development webpack alias may be enabled
-                  // es6 modules are not available in the source code
-                  // we need to remove it and use commonjs structure.
-                  newPath = module.replace(`es6${pathUtils.sep}`, '');
-                } else {
-                  newPath = module;
-                }
-                return true;
-              }
-              return false;
-            });
-            const newImportSpecifier = (
-              types.importDefaultSpecifier(types.identifier(memberImport.local.name))
-            );
-            if (newPath) {
+            // filter down to modules that match this componentName
+            const matchingModules = modulesInContext.filter(module =>
+              module.endsWith(`${pathUtils.sep}${componentName}`))
+            // sort production to have es6 first and development to have es5
+            // this is because webpack hot reloading doesn't have the es6 stuff
+            .sort((m1, m2) =>
+              ((development && m1.includes(es6)) ||
+              (!development && m2.includes(es6))) ? 1 : -1);
+            if (matchingModules.length > 0) {
+              const newImportSpecifier = (
+                types.importDefaultSpecifier(types.identifier(memberImport.local.name))
+              );
               transforms.push(types.importDeclaration(
                 [newImportSpecifier],
-                types.stringLiteral(newPath)
+                types.stringLiteral(matchingModules[0])
               ));
             }
           });

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.2",
+  "version": "0.5.3",
   "name": "babel-plugin-grommet",
   "description": "Babel plugin to transform member style imports into default imports",
   "repository": "grommet/babel-plugin-grommet",


### PR DESCRIPTION
There was an issue where grommet-icons modules were choosing es5 versions whereas grommet was choosing es6 versions. This caused multiple versions of grommet-icons ThemeContext to be loaded, which doesn't work. The reason this happened is because `reverse()` was being used to put 'es6' before 'components' in grommet but was causing 'icons' to be put before 'es6' in grommet-icons.

The change is to first filter down to matching modules and then sort to use the preferred version based on 'es6' explicitly.